### PR TITLE
fix: node server marketplace extensionDir

### DIFF
--- a/src/node/server.ts
+++ b/src/node/server.ts
@@ -42,6 +42,7 @@ function getServerAppOpts() {
       marketplace: {
         showBuiltinExtensions: true,
         ...newOpts.marketplace,
+        ...opts.marketplace,
       },
     };
   } catch (error) {}


### PR DESCRIPTION
修复启动 ide-electron 后出现如下报错：
<img width="717" alt="image" src="https://user-images.githubusercontent.com/2226423/177099524-236965cf-c10e-4062-abc5-3f0d83bd5c39.png">

因为 Node.js 进程在处理 marketplace 时把 extensionDir 属性丢失了。导致 `~/.sumi-oss/extensions` 变成了 `~/.sumi/extensions`。