### PR TITLE
fix: failed to pack the installer due to the changes of two dependencies

### DIFF
--- a/build/pack.js
+++ b/build/pack.js
@@ -58,7 +58,7 @@ electronBuilder.build({
       output: outputPath,
     },
     asar: true,
-    asarUnpack: ['node_modules/@opensumi/vscode-ripgrep'],
+    asarUnpack: ['node_modules/@opensumi/ripgrep'],
     mac: {
       icon: 'build/icon/sumi.png',
       artifactName: '${productName}-${version}-${arch}.${ext}',

--- a/build/package.json
+++ b/build/package.json
@@ -5,8 +5,8 @@
   "description": "OpenSumi Desktop",
   "private": true,
   "dependencies": {
-    "@opensumi/vscode-ripgrep": "^1.4.0",
-    "node-pty": "0.10.0",
+    "@opensumi/ripgrep": "^1.4.0",
+    "node-pty": "1.0.0",
     "@parcel/watcher": "2.1.0",
     "spdlog": "0.11.1",
     "vscode-oniguruma": "^1.5.1"

--- a/build/webpack.node.config.js
+++ b/build/webpack.node.config.js
@@ -48,9 +48,7 @@ module.exports = createConfig({
     },
     ({ context, request }, callback) => {
       if (
-        ['node-pty', '@parcel/watcher', 'spdlog', '@opensumi/vscode-ripgrep', 'vm2', 'keytar', 'vertx'].indexOf(
-          request,
-        ) !== -1
+        ['node-pty', '@parcel/watcher', 'spdlog', '@opensumi/ripgrep', 'vm2', 'keytar', 'vertx'].indexOf(request) !== -1
       ) {
         return callback(null, 'commonjs ' + request);
       }


### PR DESCRIPTION
fixes the issue that it failed to pack the installer due to the changes of two dependencies,  ripgrep and node-pty.

here is the packaging result:

```bash
$ yarn run pack
yarn run v1.22.22
$ yarn build-prod && node build/pack.js
$ rimraf -rf ./app && rimraf -rf ./out && run-p build-prod:*
$ webpack --config ./build/webpack.main.config.js --mode=production
$ webpack --config ./build/webpack.node.config.js --mode=production
$ webpack --config ./build/webpack.browser.config.js --mode=production
$ webpack --config ./build/webpack.extension-host.config.js --mode=production
$ webpack --config ./build/webpack.webview.config.js --mode=production
asset host-preload.js 9.65 KiB [emitted] [minimized] (name: main) 1 related asset
asset plain-preload.js 939 bytes [emitted] [from: node_modules/@opensumi/ide-webview/lib/electron-webview/plain-preload.js] [copied] [minimized]
modules by path ./node_modules/@opensumi/ide-webview/lib/electron-webview/*.js 2.02 KiB
  ./node_modules/@opensumi/ide-webview/lib/electron-webview/host-preload.js 54 bytes [built] [code generated]

......

webpack 5.93.0 compiled with 5 warnings in 236941 ms
  • electron-builder  version=23.6.0 os=10.0.19045
  • author is missed in the package.json  appPackageFile=C:\Users\ide\workspace\ide-electron\app\package.json
  • writing effective config  file=out\builder-effective-config.yaml
  • installing production dependencies  platform=win32 arch=x64 appDir=C:\Users\ide\workspace\ide-electron\app
  • packaging       platform=win32 arch=x64 electron=22.3.25 appOutDir=out\win-unpacked
  • building        target=nsis file=out\OpenSumi-OSS-1.3.6.exe archs=x64 oneClick=true perMachine=false
  • building block map  blockMapFile=out\OpenSumi-OSS-1.3.6.exe.blockmap
Done in 474.18s.
```